### PR TITLE
Solargraph stubs for Lograge config

### DIFF
--- a/{{cookiecutter.project_slug}}/config/annotations_solargraph_rails.rb
+++ b/{{cookiecutter.project_slug}}/config/annotations_solargraph_rails.rb
@@ -115,3 +115,17 @@
 #     # @return [void]
 #     def each(&block); end
 #   end
+#   module Lograge
+#     class Configuration
+#       # @return [Boolean]
+#       attr_accessor :enabled
+#       # @return [String]
+#       attr_accessor :base_controller_class
+#       # @return [Proc]
+#       attr_accessor :ignore_custom
+#     end
+#   end
+#   class Rails::Application::Configuration
+#     # @return [Lograge::Configuration]
+#     def lograge; end
+#   end


### PR DESCRIPTION
## Summary
- Typed config.lograge stubs in annotations_solargraph_rails.rb.

## Test plan
- [ ] CI green